### PR TITLE
first pass template engine implementation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
-# DeasNm
+# Deas::Nm
 
 [Deas](https://github.com/redding/deas) template engine for rendering [Nm](https://github.com/redding/nm) templates
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+Register the engine:
+
+```ruby
+require 'deas'
+require 'deas-nm'
+
+Deas.configure do |c|
+
+  c.template_source "/path/to/templates" do |s|
+    s.engine 'nm', Deas::Nm::TemplateEngine
+  end
+
+end
+```
+
+Add `.nm` to any template files in your template source path.  Deas will render their content using Nm when they are rendered.
+
+### Notes
+
+Nm doesn't allow overriding the template scope but instead allows you to pass in data that binds to the template scope as local methods.  By default, the view handler will be bound to Nm's scope via the `view` method in templates.  If you want to change this, provide a `'handler_local'` option when registering:
+
+```ruby
+  c.template_source "/path/to/templates" do |s|
+    s.engine 'nm', Deas::Nm::TemplateEngine, 'handler_local' => 'view_handler'
+  end
+```
 
 ## Installation
 

--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -1,5 +1,39 @@
+require 'deas/template_engine'
+require 'nm'
 require "deas-nm/version"
 
 module Deas::Nm
-  # TODO: your code goes here...
+
+  class TemplateEngine < Deas::TemplateEngine
+
+    DEFAULT_HANDLER_LOCAL = 'view'
+
+    def nm_source
+      @nm_source ||= Nm::Source.new(self.source_path)
+    end
+
+    def nm_handler_local
+      @nm_handler_local ||= (self.opts['handler_local'] || DEFAULT_HANDLER_LOCAL)
+    end
+
+    def render(template_name, view_handler, locals)
+      self.nm_source.render(template_name, render_locals(view_handler, locals))
+    end
+
+    def partial(template_name, locals)
+      self.nm_source.render(template_name, locals)
+    end
+
+    def capture_partial(template_name, locals, &content)
+      raise NotImplementedError
+    end
+
+    private
+
+    def render_locals(view_handler, locals)
+      { self.nm_handler_local => view_handler }.merge(locals)
+    end
+
+  end
+
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,4 +9,5 @@ require 'pry'
 
 require 'test/support/factory'
 
-# TODO: put test helpers here...
+require 'pathname'
+TEST_SUPPORT_PATH = Pathname.new(File.expand_path('../support', __FILE__))

--- a/test/support/_partial.json.nm
+++ b/test/support/_partial.json.nm
@@ -1,0 +1,3 @@
+node('thing') {
+  node('local1', local1)
+}

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,20 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.template_json_rendered(view_handler, locals)
+    { 'thing' => {
+        'id'     => view_handler.identifier,
+        'name'   => view_handler.name,
+        'local1' => locals['local1']
+      }
+    }
+  end
+
+  def self.partial_json_rendered(locals)
+    { 'thing' => {
+        'local1' => locals['local1']
+      }
+    }
+  end
+
 end

--- a/test/support/template.json.nm
+++ b/test/support/template.json.nm
@@ -1,0 +1,5 @@
+node('thing') {
+  node('id',     view.identifier)
+  node('name',   view.name)
+  node('local1', local1)
+}

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -1,0 +1,67 @@
+require 'assert'
+require 'deas-nm'
+
+require 'nm/source'
+require 'deas/template_engine'
+
+class Deas::Nm::TemplateEngine
+
+  class UnitTests < Assert::Context
+    desc "Deas::Nm::TemplateEngine"
+    setup do
+      @engine = Deas::Nm::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH
+      })
+    end
+    subject{ @engine }
+
+    should have_imeths :nm_source, :nm_handler_local
+    should have_imeths :render, :partial, :capture_partial
+
+    should "be a Deas template engine" do
+      assert_kind_of Deas::TemplateEngine, subject
+    end
+
+    should "memoize its Nm source" do
+      assert_kind_of Nm::Source, subject.nm_source
+      assert_equal subject.source_path, subject.nm_source.root
+      assert_same subject.nm_source, subject.nm_source
+    end
+
+    should "use 'view' as the handler local name by default" do
+      assert_equal 'view', subject.nm_handler_local
+    end
+
+    should "allow custom handler local names" do
+      handler_local = Factory.string
+      engine = Deas::Nm::TemplateEngine.new('handler_local' => handler_local)
+      assert_equal handler_local, engine.nm_handler_local
+    end
+
+    should "render nm template files" do
+      view_handler = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name => Factory.string
+      })
+      locals = { 'local1' => Factory.string }
+      exp = Factory.template_json_rendered(view_handler, locals)
+
+      assert_equal exp, subject.render('template.json', view_handler, locals)
+    end
+
+    should "render nm partials" do
+      locals = { 'local1' => Factory.string }
+      exp = Factory.partial_json_rendered(locals)
+
+      assert_equal exp, subject.partial('_partial.json', locals)
+    end
+
+    should "not implement the engine capture partial method" do
+      assert_raises NotImplementedError do
+        subject.capture_partial('_partial.json', {})
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This implements the template engine.  The `render` and `partial`
methods are implemented; the `capture_partial` method is not b/c
capturing content for rendering does not apply to Nm templates.

This implementationa and the tests were modeled after sanford-nm.
There is still one more step needed and that is to design specifying
serializers.  For Deas, we actually need to serialize the objects
Nm returns (where Sanford didn't need this).  This will be done in
a coming PR.

@jcredding ready for review.
