### PR TITLE
add in custom serialization of rendered objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,45 @@ end
 
 Add `.nm` to any template files in your template source path.  Deas will render their content using Nm when they are rendered.
 
+### Serialization
+
+Nm doesn't serialize the objects it renders - it just returns them.  However, Deas expects serialized body content.  By default, the rendered objects are not serialized.
+
+To serialize the rendered objects, specify a serializer when registering:
+
+```ruby
+# this uses Oj to serialize to JSON (for example)
+c.template_source "/path/to/templates" do |s|
+  s.engine('nm', Deas::Nm::TemplateEngine, {
+    'serializer' => proc{ |obj, template_name| Oj.dump(obj, :mode => :strict) }
+  })
+end
+```
+
+The template name is passed to any serializer proc.  This can be helpful if choosing how to serialize is conditonal upon the template name.  For example:
+
+```ruby
+c.template_source "/path/to/templates" do |s|
+  s.engine('nm', Deas::Nm::TemplateEngine, {
+    'serializer' => proc do |obj, template_name|
+      if File.extname(template_name) == '.json'
+        Oj.dump(obj, :mode => :strict)
+      else
+        # serialize some other way?
+      end
+    end
+  })
+end
+```
+
 ### Notes
 
 Nm doesn't allow overriding the template scope but instead allows you to pass in data that binds to the template scope as local methods.  By default, the view handler will be bound to Nm's scope via the `view` method in templates.  If you want to change this, provide a `'handler_local'` option when registering:
 
 ```ruby
-  c.template_source "/path/to/templates" do |s|
-    s.engine 'nm', Deas::Nm::TemplateEngine, 'handler_local' => 'view_handler'
-  end
+c.template_source "/path/to/templates" do |s|
+  s.engine 'nm', Deas::Nm::TemplateEngine, 'handler_local' => 'view_handler'
+end
 ```
 
 ## Installation

--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -6,7 +6,8 @@ module Deas::Nm
 
   class TemplateEngine < Deas::TemplateEngine
 
-    DEFAULT_HANDLER_LOCAL = 'view'
+    DEFAULT_HANDLER_LOCAL = 'view'.freeze
+    DEFAULT_SERIALIZER = proc{ |obj, template_name| obj }.freeze # no-op
 
     def nm_source
       @nm_source ||= Nm::Source.new(self.source_path)
@@ -16,12 +17,22 @@ module Deas::Nm
       @nm_handler_local ||= (self.opts['handler_local'] || DEFAULT_HANDLER_LOCAL)
     end
 
+    def nm_serializer
+      @nm_serializer ||= (self.opts['serializer'] || DEFAULT_SERIALIZER)
+    end
+
     def render(template_name, view_handler, locals)
-      self.nm_source.render(template_name, render_locals(view_handler, locals))
+      self.nm_serializer.call(
+        self.nm_source.render(template_name, render_locals(view_handler, locals)),
+        template_name
+      )
     end
 
     def partial(template_name, locals)
-      self.nm_source.render(template_name, locals)
+      self.nm_serializer.call(
+        self.nm_source.render(template_name, locals),
+        template_name
+      )
     end
 
     def capture_partial(template_name, locals, &content)

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -15,7 +15,7 @@ class Deas::Nm::TemplateEngine
     end
     subject{ @engine }
 
-    should have_imeths :nm_source, :nm_handler_local
+    should have_imeths :nm_source, :nm_handler_local, :nm_serializer
     should have_imeths :render, :partial, :capture_partial
 
     should "be a Deas template engine" do
@@ -38,22 +38,35 @@ class Deas::Nm::TemplateEngine
       assert_equal handler_local, engine.nm_handler_local
     end
 
-    should "render nm template files" do
+    should "use a no-op serializer by default" do
+      obj = Factory.integer
+      assert_equal obj, subject.nm_serializer.call(obj, Factory.string)
+    end
+
+    should "render nm template files and serialize them" do
+      engine = Deas::Nm::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH,
+        'serializer' => proc{ |obj, template_name| obj.to_s }
+      })
       view_handler = OpenStruct.new({
         :identifier => Factory.integer,
         :name => Factory.string
       })
       locals = { 'local1' => Factory.string }
-      exp = Factory.template_json_rendered(view_handler, locals)
+      exp = Factory.template_json_rendered(view_handler, locals).to_s
 
-      assert_equal exp, subject.render('template.json', view_handler, locals)
+      assert_equal exp, engine.render('template.json', view_handler, locals)
     end
 
-    should "render nm partials" do
+    should "render nm partials and serialize them" do
+      engine = Deas::Nm::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH,
+        'serializer' => proc{ |obj, template_name| obj.to_s }
+      })
       locals = { 'local1' => Factory.string }
-      exp = Factory.partial_json_rendered(locals)
+      exp = Factory.partial_json_rendered(locals).to_s
 
-      assert_equal exp, subject.partial('_partial.json', locals)
+      assert_equal exp, engine.partial('_partial.json', locals)
     end
 
     should "not implement the engine capture partial method" do


### PR DESCRIPTION
By default Nm (and this engine) do not serialize the rendered objects.
However, Deas expects serialized body content.  This allows for custom
serialization procs to be defined at registration time.

@jcredding ready for review.
