### PR TITLE
add a 'logger' local to all templates

### DIFF
--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -7,6 +7,7 @@ module Deas::Nm
   class TemplateEngine < Deas::TemplateEngine
 
     DEFAULT_HANDLER_LOCAL = 'view'.freeze
+    DEFAULT_LOGGER_LOCAL  = 'logger'.freeze
     DEFAULT_SERIALIZER = proc{ |obj, template_name| obj }.freeze # no-op
 
     def nm_source
@@ -15,6 +16,10 @@ module Deas::Nm
 
     def nm_handler_local
       @nm_handler_local ||= (self.opts['handler_local'] || DEFAULT_HANDLER_LOCAL)
+    end
+
+    def nm_logger_local
+      @nm_logger_local ||= (self.opts['logger_local'] || DEFAULT_LOGGER_LOCAL)
     end
 
     def nm_serializer
@@ -30,7 +35,7 @@ module Deas::Nm
 
     def partial(template_name, locals)
       self.nm_serializer.call(
-        self.nm_source.render(template_name, locals),
+        self.nm_source.render(template_name, default_locals(locals)),
         template_name
       )
     end
@@ -42,7 +47,11 @@ module Deas::Nm
     private
 
     def render_locals(view_handler, locals)
-      { self.nm_handler_local => view_handler }.merge(locals)
+      { self.nm_handler_local => view_handler }.merge(default_locals(locals))
+    end
+
+    def default_locals(locals)
+      { self.nm_logger_local => self.logger }.merge(locals)
     end
 
   end

--- a/test/support/_partial.json.nm
+++ b/test/support/_partial.json.nm
@@ -1,3 +1,4 @@
 node('thing') {
   node('local1', local1)
+  node('logger', logger.to_s)
 }

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,18 +3,20 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
-  def self.template_json_rendered(view_handler, locals)
+  def self.template_json_rendered(engine, view_handler, locals)
     { 'thing' => {
         'id'     => view_handler.identifier,
         'name'   => view_handler.name,
-        'local1' => locals['local1']
+        'local1' => locals['local1'],
+        'logger' => engine.logger
       }
     }
   end
 
-  def self.partial_json_rendered(locals)
+  def self.partial_json_rendered(engine, locals)
     { 'thing' => {
-        'local1' => locals['local1']
+        'local1' => locals['local1'],
+        'logger' => engine.logger
       }
     }
   end

--- a/test/support/template.json.nm
+++ b/test/support/template.json.nm
@@ -2,4 +2,5 @@ node('thing') {
   node('id',     view.identifier)
   node('name',   view.name)
   node('local1', local1)
+  node('logger', logger.to_s)
 }

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -15,7 +15,8 @@ class Deas::Nm::TemplateEngine
     end
     subject{ @engine }
 
-    should have_imeths :nm_source, :nm_handler_local, :nm_serializer
+    should have_imeths :nm_source, :nm_handler_local, :nm_logger_local
+    should have_imeths :nm_serializer
     should have_imeths :render, :partial, :capture_partial
 
     should "be a Deas template engine" do
@@ -38,6 +39,16 @@ class Deas::Nm::TemplateEngine
       assert_equal handler_local, engine.nm_handler_local
     end
 
+    should "use 'logger' as the logger local name by default" do
+      assert_equal 'logger', subject.nm_logger_local
+    end
+
+    should "allow custom logger local names" do
+      logger_local = Factory.string
+      engine = Deas::Nm::TemplateEngine.new('logger_local' => logger_local)
+      assert_equal logger_local, engine.nm_logger_local
+    end
+
     should "use a no-op serializer by default" do
       obj = Factory.integer
       assert_equal obj, subject.nm_serializer.call(obj, Factory.string)
@@ -53,7 +64,7 @@ class Deas::Nm::TemplateEngine
         :name => Factory.string
       })
       locals = { 'local1' => Factory.string }
-      exp = Factory.template_json_rendered(view_handler, locals).to_s
+      exp = Factory.template_json_rendered(engine, view_handler, locals).to_s
 
       assert_equal exp, engine.render('template.json', view_handler, locals)
     end
@@ -64,7 +75,7 @@ class Deas::Nm::TemplateEngine
         'serializer' => proc{ |obj, template_name| obj.to_s }
       })
       locals = { 'local1' => Factory.string }
-      exp = Factory.partial_json_rendered(locals).to_s
+      exp = Factory.partial_json_rendered(engine, locals).to_s
 
       assert_equal exp, engine.partial('_partial.json', locals)
     end


### PR DESCRIPTION
This exposes the engine's logger to the templates as a local so
you can log from inside your template renders.  Previously there
was no way to log output from the templates themselves.

By default, `logger` is the name of the local but this can be
overridden with the `'logger_local'` option.

@jcredding ready for review.
