### PR TITLE
require latest Nm; pass in logger as a default source local

### DIFF
--- a/deas-nm.gemspec
+++ b/deas-nm.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert", ["~> 2.12"])
 
   gem.add_dependency("deas", ["~> 0.28"])
-  gem.add_dependency("nm")
+  gem.add_dependency("nm",   ["~> 0.4"])
 
 end

--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -11,7 +11,9 @@ module Deas::Nm
     DEFAULT_SERIALIZER = proc{ |obj, template_name| obj }.freeze # no-op
 
     def nm_source
-      @nm_source ||= Nm::Source.new(self.source_path)
+      @nm_source ||= Nm::Source.new(self.source_path, {
+        self.nm_logger_local => self.logger
+      })
     end
 
     def nm_handler_local
@@ -35,7 +37,7 @@ module Deas::Nm
 
     def partial(template_name, locals)
       self.nm_serializer.call(
-        self.nm_source.render(template_name, default_locals(locals)),
+        self.nm_source.render(template_name, locals),
         template_name
       )
     end
@@ -47,11 +49,7 @@ module Deas::Nm
     private
 
     def render_locals(view_handler, locals)
-      { self.nm_handler_local => view_handler }.merge(default_locals(locals))
-    end
-
-    def default_locals(locals)
-      { self.nm_logger_local => self.logger }.merge(locals)
+      { self.nm_handler_local => view_handler }.merge(locals)
     end
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -8,7 +8,7 @@ module Factory
         'id'     => view_handler.identifier,
         'name'   => view_handler.name,
         'local1' => locals['local1'],
-        'logger' => engine.logger
+        'logger' => engine.logger.to_s
       }
     }
   end
@@ -16,7 +16,23 @@ module Factory
   def self.partial_json_rendered(engine, locals)
     { 'thing' => {
         'local1' => locals['local1'],
-        'logger' => engine.logger
+        'logger' => engine.logger.to_s
+      }
+    }
+  end
+
+  def self.template_partial_json_rendered(engine, view_handler, locals)
+    { 'thing' => {
+        'id'     => view_handler.identifier,
+        'name'   => view_handler.name,
+        'local1' => locals['local1'],
+        'logger' => engine.logger.to_s
+      },
+      'partial' => {
+        'thing' => {
+          'local1' => locals['local1'],
+          'logger' => engine.logger.to_s
+        }
       }
     }
   end

--- a/test/support/template_partial.json.nm
+++ b/test/support/template_partial.json.nm
@@ -1,0 +1,10 @@
+node('thing') {
+  node('id',     view.identifier)
+  node('name',   view.name)
+  node('local1', local1)
+  node('logger', logger.to_s)
+}
+
+node 'partial' do
+  partial('_partial.json', 'local1' => local1)
+end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -86,6 +86,21 @@ class Deas::Nm::TemplateEngine
       end
     end
 
+    should "render nm templates that render partials and serialize them" do
+      engine = Deas::Nm::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH,
+        'serializer' => proc{ |obj, template_name| obj.to_s }
+      })
+      view_handler = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name => Factory.string
+      })
+      locals = { 'local1' => Factory.string }
+      exp = Factory.template_partial_json_rendered(engine, view_handler, locals).to_s
+
+      assert_equal exp, engine.render('template_partial.json', view_handler, locals)
+    end
+
   end
 
 end


### PR DESCRIPTION
This version implements source locals.  This switches to using them
instead of manually passing in the logger on renders.  This ensures
the logger is always available as a local - even on sub-partial
renders in template renders.

@jcredding ready for review.
