### PR TITLE
formally not implement the latest Deas render api `compile` method

### DIFF
--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -46,6 +46,10 @@ module Deas::Nm
       raise NotImplementedError
     end
 
+    def compile(template_name, compiled_content)
+      raise NotImplementedError
+    end
+
     private
 
     def render_locals(view_handler, locals)

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -86,6 +86,12 @@ class Deas::Nm::TemplateEngine
       end
     end
 
+    should "not implement the engine compile method" do
+      assert_raises NotImplementedError do
+        subject.compile('_partial.json', Factory.text)
+      end
+    end
+
     should "render nm templates that render partials and serialize them" do
       engine = Deas::Nm::TemplateEngine.new({
         'source_path' => TEST_SUPPORT_PATH,


### PR DESCRIPTION
This method will be used when rendering templates with multiple
engines.  The idea is that an upstream engine will read the file
and do an initial render pass.  The output will then be compiled
by all downstream engines.

This method, like `capture_partial` doesn't really apply to Nm
templates.  Typically something like Erb is used upstream to add
dynamic template markup.  This isn't needed b/c Nm is interpreted
as Ruby and is already dynamic.  Also, Nm doesn't support rendering
from raw content right now.

Should a pattern or need arise in the future, Nm will need to be
updated to render raw content.  Then this engine can be updated
to support this API method.

@jcredding ready for review.