### PR TITLE
update render api to take an option content block

### DIFF
--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -28,7 +28,7 @@ module Deas::Nm
       @nm_serializer ||= (self.opts['serializer'] || DEFAULT_SERIALIZER)
     end
 
-    def render(template_name, view_handler, locals)
+    def render(template_name, view_handler, locals, &content)
       self.nm_serializer.call(
         self.nm_source.render(template_name, render_locals(view_handler, locals)),
         template_name


### PR DESCRIPTION
This is the standard Deas expects.  In this case it is ignored.
This means rendering with layouts is not supported.

This is really just about having this engines implementation match
the base Deas template engine spec.  The render method can take
a content block, whether the engine does anything with it or not.

See redding/deas#159 for reference.
See redding/deas-erubis#11 for reference.

@jcredding ready for review.  I know this PR is super light - mainly wanting to document the thought process and get your eyes on it. :)