### PR TITLE
update to latest Deas render API; test cleanups

### DIFF
--- a/deas-nm.gemspec
+++ b/deas-nm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.12"])
 
-  gem.add_dependency("deas", ["~> 0.28"])
+  gem.add_dependency("deas", ["~> 0.29"])
   gem.add_dependency("nm",   ["~> 0.4"])
 
 end

--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -35,15 +35,11 @@ module Deas::Nm
       )
     end
 
-    def partial(template_name, locals)
+    def partial(template_name, locals, &content)
       self.nm_serializer.call(
         self.nm_source.render(template_name, locals),
         template_name
       )
-    end
-
-    def capture_partial(template_name, locals, &content)
-      raise NotImplementedError
     end
 
     def compile(template_name, compiled_content)

--- a/test/system/template_engine_tests.rb
+++ b/test/system/template_engine_tests.rb
@@ -1,0 +1,39 @@
+require 'assert'
+require 'deas-nm'
+
+class Deas::Nm::TemplateEngine
+
+  class SystemTests < Assert::Context
+    desc "Deas::Nm::TemplateEngine"
+    setup do
+      @view = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name => Factory.string
+      })
+      @locals = { 'local1' => Factory.string }
+
+      @engine = Deas::Nm::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH,
+        'serializer' => proc{ |obj, template_name| obj.to_s }
+      })
+    end
+    subject{ @engine }
+
+    should "render nm template files and serialize them" do
+      exp = Factory.template_json_rendered(subject, @view, @locals).to_s
+      assert_equal exp, subject.render('template.json', @view, @locals)
+    end
+
+    should "render nm partials and serialize them" do
+      exp = Factory.partial_json_rendered(subject, @locals).to_s
+      assert_equal exp, subject.partial('_partial.json', @locals)
+    end
+
+    should "render nm templates that render partials and serialize them" do
+      exp = Factory.template_partial_json_rendered(subject, @view, @locals).to_s
+      assert_equal exp, subject.render('template_partial.json', @view, @locals)
+    end
+
+  end
+
+end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -17,7 +17,7 @@ class Deas::Nm::TemplateEngine
 
     should have_imeths :nm_source, :nm_handler_local, :nm_logger_local
     should have_imeths :nm_serializer
-    should have_imeths :render, :partial, :capture_partial
+    should have_imeths :render, :partial, :compile
 
     should "be a Deas template engine" do
       assert_kind_of Deas::TemplateEngine, subject
@@ -54,57 +54,10 @@ class Deas::Nm::TemplateEngine
       assert_equal obj, subject.nm_serializer.call(obj, Factory.string)
     end
 
-    should "render nm template files and serialize them" do
-      engine = Deas::Nm::TemplateEngine.new({
-        'source_path' => TEST_SUPPORT_PATH,
-        'serializer' => proc{ |obj, template_name| obj.to_s }
-      })
-      view_handler = OpenStruct.new({
-        :identifier => Factory.integer,
-        :name => Factory.string
-      })
-      locals = { 'local1' => Factory.string }
-      exp = Factory.template_json_rendered(engine, view_handler, locals).to_s
-
-      assert_equal exp, engine.render('template.json', view_handler, locals)
-    end
-
-    should "render nm partials and serialize them" do
-      engine = Deas::Nm::TemplateEngine.new({
-        'source_path' => TEST_SUPPORT_PATH,
-        'serializer' => proc{ |obj, template_name| obj.to_s }
-      })
-      locals = { 'local1' => Factory.string }
-      exp = Factory.partial_json_rendered(engine, locals).to_s
-
-      assert_equal exp, engine.partial('_partial.json', locals)
-    end
-
-    should "not implement the engine capture partial method" do
-      assert_raises NotImplementedError do
-        subject.capture_partial('_partial.json', {})
-      end
-    end
-
     should "not implement the engine compile method" do
       assert_raises NotImplementedError do
         subject.compile('_partial.json', Factory.text)
       end
-    end
-
-    should "render nm templates that render partials and serialize them" do
-      engine = Deas::Nm::TemplateEngine.new({
-        'source_path' => TEST_SUPPORT_PATH,
-        'serializer' => proc{ |obj, template_name| obj.to_s }
-      })
-      view_handler = OpenStruct.new({
-        :identifier => Factory.integer,
-        :name => Factory.string
-      })
-      locals = { 'local1' => Factory.string }
-      exp = Factory.template_partial_json_rendered(engine, view_handler, locals).to_s
-
-      assert_equal exp, engine.render('template_partial.json', view_handler, locals)
     end
 
   end


### PR DESCRIPTION
This brings in the latest Deas and conforms to its render API.  This
means taking content blocks on the partial method and removing the
capture partial method.

This also cleans up the tests by organizing the the tests that actually
render as system tests.  This also better commonized the setup logic
for those tests.

@jcredding similar to redding/deas-erubis#13.  Ready for review