### PR TITLE
update to the latest Nm; expose the new source `:cache` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ c.template_source "/path/to/templates" do |s|
 end
 ```
 
+Nm doesn't cache templates by default.  To enable caching, pass a `'cache'` option when registering:
+
+```ruby
+  c.template_source "/path/to/templates" do |s|
+    s.engine 'nm', Deas::Nm::TemplateEngine, 'cache' => true
+  end
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/deas-nm.gemspec
+++ b/deas-nm.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert", ["~> 2.12"])
 
   gem.add_dependency("deas", ["~> 0.29"])
-  gem.add_dependency("nm",   ["~> 0.4"])
+  gem.add_dependency("nm",   ["~> 0.5"])
 
 end

--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -12,7 +12,8 @@ module Deas::Nm
 
     def nm_source
       @nm_source ||= Nm::Source.new(self.source_path, {
-        self.nm_logger_local => self.logger
+        :cache  => self.opts['cache'],
+        :locals => { self.nm_logger_local => self.logger }
       })
     end
 

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -39,6 +39,11 @@ class Deas::Nm::TemplateEngine
       assert_equal handler_local, engine.nm_handler_local
     end
 
+    should "pass any given cache option to the Nm source" do
+      engine = Deas::Nm::TemplateEngine.new('cache' => true)
+      assert_kind_of Hash, engine.nm_source.cache
+    end
+
     should "use 'logger' as the logger local name by default" do
       assert_equal 'logger', subject.nm_logger_local
     end


### PR DESCRIPTION
This allows you to integrate the engine and tell Nm to cache templates.

@jcredding ready for review.