### PR TITLE
Pass deas template engine ext to nm source

### DIFF
--- a/deas-nm.gemspec
+++ b/deas-nm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.1"])
 
-  gem.add_dependency("deas", ["~> 0.39.2"])
-  gem.add_dependency("nm",   ["~> 0.5.1"])
+  gem.add_dependency("deas", ["~> 0.40.0"])
+  gem.add_dependency("nm",   ["~> 0.5.2"])
 
 end

--- a/lib/deas-nm.rb
+++ b/lib/deas-nm.rb
@@ -13,6 +13,7 @@ module Deas::Nm
     def nm_source
       @nm_source ||= Nm::Source.new(self.source_path, {
         :cache  => self.opts['cache'],
+        :ext    => self.opts['ext'],
         :locals => { self.nm_logger_local => self.logger }
       })
     end

--- a/test/support/template.json.aaa
+++ b/test/support/template.json.aaa
@@ -1,0 +1,4 @@
+# This files is just to provide a conflict when rendering. If deas-nm isn't
+# passing an extension down to nm then nm will try and render this file which
+# will error.
+raise "oops - trying to render wrong template"

--- a/test/system/template_engine_tests.rb
+++ b/test/system/template_engine_tests.rb
@@ -14,7 +14,8 @@ class Deas::Nm::TemplateEngine
 
       @engine = Deas::Nm::TemplateEngine.new({
         'source_path' => TEST_SUPPORT_PATH,
-        'serializer' => proc{ |obj, template_name| obj.to_s }
+        'ext'         => 'nm',
+        'serializer'  => proc{ |obj, template_name| obj.to_s }
       })
     end
     subject{ @engine }

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -10,7 +10,8 @@ class Deas::Nm::TemplateEngine
     desc "Deas::Nm::TemplateEngine"
     setup do
       @engine = Deas::Nm::TemplateEngine.new({
-        'source_path' => TEST_SUPPORT_PATH
+        'source_path' => TEST_SUPPORT_PATH,
+        'ext'         => 'nm'
       })
     end
     subject{ @engine }
@@ -42,6 +43,12 @@ class Deas::Nm::TemplateEngine
     should "pass any given cache option to the Nm source" do
       engine = Deas::Nm::TemplateEngine.new('cache' => true)
       assert_kind_of Hash, engine.nm_source.cache
+    end
+
+    should "pass any given ext option to the Nm source" do
+      ext = Factory.string
+      engine = Deas::Nm::TemplateEngine.new('ext' => ext)
+      assert_equal ".#{ext}", engine.nm_source.ext
     end
 
     should "use 'logger' as the logger local name by default" do


### PR DESCRIPTION
This updates the template engine to pass its ext to nm source. The
template engine ext is set by deas when the engine is registered.
This makes it so nm will use templates with the extension that was
used when registering the engine with deas. This is the expected
behavior and avoids confusion with nm randomly not using a template
that matches the registered extension.

This is part of fixing an issue with deas not rendering the
expected nm template. This is because the nm engine no longer
forced templates extension to be `nm` (see redding/nm#16). By not
expecting an extension, the nm engine can't pick the correct file
as the template if there are multiple files with the same name
except for their extensions. For example, a common pattern is to
name a handler file and the template the same only the handler will
have `.rb` for its extension and the template would use `.nm`. In
this scenario, it's possible for the nm engine to try and use the
ruby file as its template. Nm is being updated to use a custom
extension (the one deas-nm will now pass to it) to address this
issue (redding/nm#17).

@kellyredding - Ready for review.