### PR TITLE
get working in modern ruby versions

### DIFF
--- a/deas-nm.gemspec
+++ b/deas-nm.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("deas", ["~> 0.40.0"])
-  gem.add_dependency("nm",   ["~> 0.5.2"])
+  gem.add_dependency("deas", ["~> 0.41.0"])
+  gem.add_dependency("nm",   ["~> 0.5.3"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,3 +11,12 @@ require 'test/support/factory'
 
 require 'pathname'
 TEST_SUPPORT_PATH = Pathname.new(File.expand_path('../support', __FILE__))
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

@jcredding ready for review.
